### PR TITLE
fix comparison of unicode

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@
           } else if (comp < 0) {
             return SMALLER;
           } else {
-            return 0;
+            continue;
           }
         }
 

--- a/test/spec/unicode.spec.js
+++ b/test/spec/unicode.spec.js
@@ -18,4 +18,14 @@ describe('unicode: ', function () {
     ]);
   });
 
+  it('unicode string', function () {
+    expect([
+      '\u30c6\u30b9\u30c8 10.txt',
+      '\u30c6\u30b9\u30c8 2.txt',
+    ].sort(natsort())).to.eql([
+      '\u30c6\u30b9\u30c8 2.txt',
+      '\u30c6\u30b9\u30c8 10.txt',
+    ]);
+  });
+
 });


### PR DESCRIPTION
I found a unicode sort bug.

```
['テスト 10.txt', 'テスト 2.txt'].natsort();

// => return ['テスト 10.txt', 'テスト 2.txt']
// "テスト" means "test" in Japanese.
// "テスト" === "\u30c6\u30b9\u30c8"
```

Because return 0 if localeCompare is defined and result of comparison of "テスト" and "テスト" contained in xArr[0] and yArr[0] is equal.
https://github.com/bubkoo/natsort/blob/master/index.js#L129

As a result, comparison of "2" and "10" contained in xArr[1] and yArr[1] is not executed.
