### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ First, include the script located on the `dist` folder:
 Or load it from [jsdelivr](http://www.jsdelivr.com/projects/natsort):
 
 ```html
-<script src="https://cdn.jsdelivr.net/natsort/<version>/natsort.min.js"></script>
-<script src="https://cdn.jsdelivr.net/natsort/latest/natsort.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/natsort@<version>/index.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/natsort@latest/index.min.js"></script>
 ```
 
 ## Usage


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/natsort.

Feel free to ping me if you have any questions regarding this change.